### PR TITLE
Use one place to resolve dependencies versions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,35 +5,33 @@ plugins {
 dependencies {
 
     // Base
-    implementation("androidx.core:core-ktx:1.6.0")
-    implementation("androidx.appcompat:appcompat:1.3.1")
+    implementation("androidx.core:core-ktx")
+    implementation("androidx.appcompat:appcompat")
 
     // Rx
-    implementation("io.reactivex.rxjava2:rxjava:2.2.21")
-    implementation("io.reactivex.rxjava2:rxandroid:2.1.1")
+    implementation("io.reactivex.rxjava2:rxjava")
+    implementation("io.reactivex.rxjava2:rxandroid")
 
     // Network
-    implementation("com.squareup.retrofit2:retrofit:2.9.0")
-    implementation("com.squareup.retrofit2:adapter-rxjava2:2.9.0")
-    implementation("com.squareup.retrofit2:converter-gson:2.9.0")
-    implementation("com.squareup.okhttp3:logging-interceptor:4.9.1")
+    implementation("com.squareup.retrofit2:retrofit")
+    implementation("com.squareup.retrofit2:adapter-rxjava2")
+    implementation("com.squareup.retrofit2:converter-gson")
+    implementation("com.squareup.okhttp3:logging-interceptor")
 
     // UI
-    implementation("androidx.constraintlayout:constraintlayout:2.1.1")
-    implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
-    implementation("com.google.android.material:material:1.4.0")
+    implementation("androidx.constraintlayout:constraintlayout")
+    implementation("androidx.swiperefreshlayout:swiperefreshlayout")
+    implementation("com.google.android.material:material")
 
     // Images
-    implementation("com.github.bumptech.glide:glide:4.12.0")
+    implementation("com.github.bumptech.glide:glide")
 
     // Unit tests
     // (Required) Writing and executing Unit Tests on the JUnit Platform
-    testImplementation("io.kotest:kotest-runner-junit5:4.6.3")
-    testImplementation("io.kotest:kotest-assertions-core:4.6.3")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.0")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.0")
+    testImplementation("io.kotest:kotest-runner-junit5")
+    testImplementation("io.kotest:kotest-assertions-core")
+    testImplementation("org.junit.jupiter:junit-jupiter-api")
 
     // UI tests
-    androidTestImplementation("androidx.test.ext:junit:1.1.3")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
+    androidTestImplementation("androidx.test.ext:junit")
 }

--- a/gradle/platform/build.gradle.kts
+++ b/gradle/platform/build.gradle.kts
@@ -1,0 +1,41 @@
+plugins {
+    id("com.bykov.platform")
+}
+
+dependencies {
+    api(platform("org.junit:junit-bom:5.7.2")) { (this as ExternalModuleDependency).version { reject("[5.8.0,)") } } // Do not Upgrade to 5.8: https://github.com/gradle/gradle/issues/18627
+}
+
+dependencies.constraints {
+
+    // Base
+    api("androidx.core:core-ktx:1.6.0")
+    api("androidx.appcompat:appcompat:1.3.1")
+
+    // Rx
+    api("io.reactivex.rxjava2:rxjava:2.2.21")
+    api("io.reactivex.rxjava2:rxandroid:2.1.1")
+
+    // Network
+    api("com.squareup.retrofit2:retrofit:2.9.0")
+    api("com.squareup.retrofit2:adapter-rxjava2:2.9.0")
+    api("com.squareup.retrofit2:converter-gson:2.9.0")
+    api("com.squareup.okhttp3:logging-interceptor:4.9.1")
+
+    // UI
+    api("androidx.constraintlayout:constraintlayout:2.1.1")
+    api("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
+    api("com.google.android.material:material:1.4.0")
+
+    // Images
+    api("com.github.bumptech.glide:glide:4.12.0")
+
+    // Unit tests
+    // (Required) Writing and executing Unit Tests on the JUnit Platform
+    api("io.kotest:kotest-runner-junit5:4.6.3")
+    api("io.kotest:kotest-assertions-core:4.6.3")
+
+    // UI tests
+    api("androidx.test.ext:junit:1.1.3")
+    api("androidx.test.espresso:espresso-core:3.4.0")
+}

--- a/gradle/platform/settings.gradle.kts
+++ b/gradle/platform/settings.gradle.kts
@@ -1,0 +1,6 @@
+pluginManagement {
+    includeBuild("../settings")
+}
+plugins {
+    id("com.bykov.settings")
+}

--- a/gradle/plugins/android-plugins/src/main/kotlin/com.bykov.android-application.gradle.kts
+++ b/gradle/plugins/android-plugins/src/main/kotlin/com.bykov.android-application.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 plugins {
     id("com.android.application")
     id("com.bykov.android")
@@ -48,7 +50,10 @@ dependencies {
     // Can't declare dependency from the platform in com.bykov.android convention plugin
     // cause com.android.base doesn't support it
     implementation(platform("com.bykov.aboutfootball:platform"))
+    androidTestImplementation(platform("com.bykov.aboutfootball:platform"))
+
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 
+    @Suppress("UnstableApiUsage")
     androidTestRuntimeOnly("androidx.test.espresso:espresso-core")
 }

--- a/gradle/plugins/android-plugins/src/main/kotlin/com.bykov.android-application.gradle.kts
+++ b/gradle/plugins/android-plugins/src/main/kotlin/com.bykov.android-application.gradle.kts
@@ -45,6 +45,9 @@ android {
 
 // Configure common test runtime dependencies for *all* android projects
 dependencies {
+    // Can't declare dependency from the platform in com.bykov.android convention plugin
+    // cause com.android.base doesn't support it
+    implementation(platform("com.bykov.aboutfootball:platform"))
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 
     androidTestRuntimeOnly("androidx.test.espresso:espresso-core")

--- a/gradle/plugins/android-plugins/src/main/kotlin/com.bykov.android-library.gradle.kts
+++ b/gradle/plugins/android-plugins/src/main/kotlin/com.bykov.android-library.gradle.kts
@@ -1,10 +1,12 @@
+@file:Suppress("UnstableApiUsage")
+
 plugins {
     id("com.android.library")
     id("com.bykov.android")
 }
 
 android {
-    compileSdk = 30
+    compileSdk = 31
 
     defaultConfig {
         minSdk = 26
@@ -17,6 +19,8 @@ dependencies {
     // Can't declare dependency from the platform in com.bykov.android convention plugin
     // cause com.android.base doesn't support it
     implementation(platform("com.bykov.aboutfootball:platform"))
+    androidTestImplementation(platform("com.bykov.aboutfootball:platform"))
+
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 
     androidTestRuntimeOnly("androidx.test.espresso:espresso-core")

--- a/gradle/plugins/android-plugins/src/main/kotlin/com.bykov.android-library.gradle.kts
+++ b/gradle/plugins/android-plugins/src/main/kotlin/com.bykov.android-library.gradle.kts
@@ -14,6 +14,9 @@ android {
 
 // Configure common test runtime dependencies for *all* android projects
 dependencies {
+    // Can't declare dependency from the platform in com.bykov.android convention plugin
+    // cause com.android.base doesn't support it
+    implementation(platform("com.bykov.aboutfootball:platform"))
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 
     androidTestRuntimeOnly("androidx.test.espresso:espresso-core")

--- a/gradle/plugins/base-plugins/src/main/kotlin/com.bykov.platform.gradle.kts
+++ b/gradle/plugins/base-plugins/src/main/kotlin/com.bykov.platform.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    id("java-platform")
+    id("com.bykov.base")
+}
+
+// Depend on other Platforms/BOMs to align versions for libraries that consist of multiple components (like Jackson)
+javaPlatform.allowDependencies()

--- a/gradle/plugins/plugins-platform/build.gradle.kts
+++ b/gradle/plugins/plugins-platform/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("java-platform")
 }
 
+// Declare versions of the plugins here
 dependencies.constraints {
     api("com.android.tools.build:gradle:7.2.0")
     api("com.autonomousapps:dependency-analysis-gradle-plugin:1.2.0")


### PR DESCRIPTION
- Add com.bykov.platform convention plugin
- Add platform project that is used in android-application and android-library convention plugins
- Remove versions from build.gradle.kts in the app module

Closes #7 